### PR TITLE
Add a test for jmp_buf/sigjmp_buf layout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,28 +179,36 @@ use libc::c_int;
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 
+/// This are the accessible fields when viewed via a JmpBuf pointer.
 #[repr(C)]
-pub struct JmpBufStruct {
+pub struct JmpBufFields {
     _buf: [u64; 8],
     _neither_send_nor_sync: PhantomData<*const u8>,
 }
 
-/// This is the type of the first argument that is fed to longjmp.
-pub type JmpBuf = *const JmpBufStruct;
-
-/// This is the type of the first argument that is fed to siglongjmp.
-pub type SigJmpBuf = *const SigJmpBufStruct;
-
+/// This are the accessible fields when viewed via a SigJmpBuf pointer.
 #[repr(C)]
-pub struct SigJmpBufStruct {
+pub struct SigJmpBufFields {
     // This *must* be the first field. We allow `SigJmpBuf` to be transmuted to
     // a `JmpBuf` and then back again depending on the host libc. (e.g. glibc
     // has setjmp as a shallow wrapper around sigsetjmp, and will write to
     // fields past the `__jmp_buf`).
-    __jmp_buf: JmpBufStruct,
+    __jmp_buf: JmpBufFields,
     __mask_was_saved: isize,
     __saved_mask: libc::sigset_t,
 }
+
+/// This is the type of the first argument that is fed to longjmp.
+pub type JmpBuf = *const JmpBufFields;
+
+/// This is the type of the first argument that is fed to siglongjmp.
+pub type SigJmpBuf = *const SigJmpBufFields;
+
+/// This is the type you use to allocate a JmpBuf on the stack.
+pub type JmpBufStruct = SigJmpBufFields;
+
+/// This is the type you use to allocate a SigJmpBuf on the stack.
+pub type SigJmpBufStruct = SigJmpBufFields;
 
 extern "C" {
     /// Given a calling environment `jbuf` (which one can acquire via
@@ -294,11 +302,11 @@ extern "C" {
 /// of the callback can use longjmp to exit early from the call_with_setjmp.
 pub fn call_with_setjmp<F>(mut callback: F) -> c_int
 where
-    F: for<'a> FnOnce(&'a JmpBufStruct) -> c_int,
+    F: for<'a> FnOnce(&'a JmpBufFields) -> c_int,
 {
     extern "C" fn call_from_c_to_rust<F>(jbuf: JmpBuf, closure_env_ptr: *mut F) -> c_int
     where
-        F: for<'a> FnOnce(&'a JmpBufStruct) -> c_int,
+        F: for<'a> FnOnce(&'a JmpBufFields) -> c_int,
     {
         unsafe { (closure_env_ptr.read())(&*jbuf) }
     }
@@ -345,11 +353,11 @@ where
 /// of the callback can use siglongjmp to exit early from the call_with_sigsetjmp.
 pub fn call_with_sigsetjmp<F>(savemask: bool, mut callback: F) -> c_int
 where
-    F: for<'a> FnOnce(&'a SigJmpBufStruct) -> c_int,
+    F: for<'a> FnOnce(&'a SigJmpBufFields) -> c_int,
 {
     extern "C" fn call_from_c_to_rust<F>(jbuf: SigJmpBuf, closure_env_ptr: *mut F) -> c_int
     where
-        F: for<'a> FnOnce(&'a SigJmpBufStruct) -> c_int,
+        F: for<'a> FnOnce(&'a SigJmpBufFields) -> c_int,
     {
         unsafe { (closure_env_ptr.read())(&*jbuf) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -514,4 +514,32 @@ mod tests {
             7
         );
     }
+
+    #[cfg(feature = "test_c_integration")]
+    #[test]
+    fn check_c_layout() {
+        // This type is defined in test_c_integration
+        #[repr(C)]
+        #[derive(Copy, Clone, Default, Debug)]
+        struct LayoutOfJmpBufs {
+            jb_size: usize,
+            jb_align: usize,
+            sigjb_size: usize,
+            sigjb_align: usize,
+        }
+
+        extern "C" {
+            fn get_c_jmpbuf_layout() -> LayoutOfJmpBufs;
+        }
+
+        let cinfo = unsafe { get_c_jmpbuf_layout() };
+        // Dump the info so that if the test fails the right values are easy
+        // enough to find.
+        eprintln!("Note: C jmp_buf/sigjmp_buf layout info: {cinfo:?}");
+
+        assert_eq!(cinfo.jb_size, core::mem::size_of::<JmpBufStruct>());
+        assert_eq!(cinfo.jb_align, core::mem::align_of::<JmpBufStruct>());
+        assert_eq!(cinfo.sigjb_size, core::mem::size_of::<SigJmpBufStruct>());
+        assert_eq!(cinfo.sigjb_align, core::mem::align_of::<SigJmpBufStruct>());
+    }
 }

--- a/src/test_c_integration.c
+++ b/src/test_c_integration.c
@@ -1,9 +1,28 @@
 #include <setjmp.h>
 #include <stdint.h>
+#include <stddef.h>
 
 uint32_t subtract_but_longjmp_if_underflow(jmp_buf env, uint32_t a, uint32_t b) {
     if (b > a) {
         longjmp(env, b - a);
     }
     return a - b;
+}
+
+struct LayoutOfJmpBufs {
+    size_t jb_size;
+    size_t jb_align;
+
+    size_t sigjb_size;
+    size_t sigjb_align;
+};
+
+struct LayoutOfJmpBufs get_c_jmpbuf_layout(void) {
+    struct LayoutOfJmpBufs info = {0};
+    info.jb_size = sizeof(jmp_buf);
+    // Hopefully it is fine to use C11's `_Alignof` by now...
+    info.jb_align = _Alignof(jmp_buf);
+    info.sigjb_size = sizeof(sigjmp_buf);
+    info.sigjb_align = _Alignof(sigjmp_buf);
+    return info;
 }


### PR DESCRIPTION
Thanks for the crate, something like this has been on my TODO list for a while. The layout is not portable, even to other unixes. Concretely, this test fails on macOS for now (my dev environment).

The right values for macOS are:

- for x86_64 macos: on x86_64 it's an `int[37]` for `jmp_buf` and `int[38]` for `sigjmp_buf` ( `LayoutOfJmpBufs { jb_size: 148, jb_align: 4, sigjb_size: 152, sigjb_align: 4 }`)
- for aarch64 macos (irrelevant prior to #3): it's similar, `int[48]` for jmp_buf and `int[49]` for sigjmp_buf.

Fixing this should be easy, although I'm not sure what the current values are for. Are they linux x86_64? that is what it looks like.