### PR TITLE
Add support for RISC V

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/pnkfelix/cee-scape"
 documentation = "https://docs.rs/cee-scape/"
 repository = "https://github.com/pnkfelix/cee-scape"
 readme = "README.md"
+build = "build/main.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/build/get_riscv64_consts.c
+++ b/build/get_riscv64_consts.c
@@ -1,0 +1,9 @@
+#include <setjmp.h>
+
+#if defined __riscv_float_abi_double
+CEE_SCAPE_FLOAT_ABI_DOUBLE
+#endif
+
+#if defined __riscv_float_abi_soft
+CEE_SCAPE_FLOAT_ABI_SOFT
+#endif

--- a/build/main.rs
+++ b/build/main.rs
@@ -1,3 +1,5 @@
+use std::{fs::File, io::Write, path::PathBuf};
+
 fn main() {
     if std::env::var("CARGO_FEATURE_TEST_C_INTEGRATION")
         .ok()

--- a/build/main.rs
+++ b/build/main.rs
@@ -21,4 +21,42 @@ fn main() {
             .compile("interop_via_c");
     } else {
     }
+
+    if cfg!(target_arch = "riscv64") {
+        generate_riscv64_consts();
+    }
+}
+
+fn generate_riscv64_consts() {
+    println!("cargo:rerun-if-changed=build/get_riscv64_consts.c");
+
+    let expanded = cc::Build::new().file("build/get_riscv64_consts.c").expand();
+    let expanded = String::from_utf8(expanded).unwrap();
+
+    let mut float_abi_double = false;
+    let mut float_abi_soft = false;
+    for line in expanded.lines() {
+        match line.trim() {
+            "CEE_SCAPE_FLOAT_ABI_DOUBLE" => float_abi_double = true,
+            "CEE_SCAPE_FLOAT_ABI_SOFT" => float_abi_soft = true,
+            _ => {}
+        }
+    }
+
+    let out_dir: PathBuf = std::env::var("OUT_DIR")
+        .expect("OUT_DIR env variable should be available")
+        .into();
+    println!("cargo::rustc-env=OUT_DIR={}", out_dir.display());
+
+    let mut riscv64_consts_file = File::create(out_dir.join("riscv64_consts.rs"))
+        .expect("unable to create riscv64_consts.rs");
+    writeln!(
+        riscv64_consts_file,
+        "const FLOAT_ABI_DOUBLE: bool = {float_abi_double};\n\
+        const FLOAT_ABI_SOFT: bool = {float_abi_soft};"
+    )
+    .expect("unable to write to riscv64_consts.rs");
+    riscv64_consts_file
+        .flush()
+        .expect("unable to write to riscv64_consts.rs");
 }

--- a/src/asm_based.rs
+++ b/src/asm_based.rs
@@ -56,8 +56,8 @@
 
 use crate::{JmpBuf, JmpBufFields, JmpBufStruct};
 use crate::{SigJmpBuf, SigJmpBufFields, SigJmpBufStruct};
-use libc::c_int;
 use core::mem::MaybeUninit;
+use libc::c_int;
 
 #[cfg(target_arch = "x86_64")]
 macro_rules! maybesig_setjmp_asm {

--- a/src/cee_based.rs
+++ b/src/cee_based.rs
@@ -2,11 +2,18 @@ use crate::{JmpBuf, JmpBufFields};
 use crate::{SigJmpBuf, SigJmpBufFields};
 use libc::{c_int, c_void};
 
-#[link(name = "interop_via_c", kind="static")]
+#[link(name = "interop_via_c", kind = "static")]
 extern "C" {
-    fn call_closure_with_setjmp(closure_env_ptr: *mut c_void, closure_code: extern "C" fn(jbuf: *const JmpBufFields, env_ptr: *mut c_void) -> c_int) -> c_int;
+    fn call_closure_with_setjmp(
+        closure_env_ptr: *mut c_void,
+        closure_code: extern "C" fn(jbuf: *const JmpBufFields, env_ptr: *mut c_void) -> c_int,
+    ) -> c_int;
 
-    fn call_closure_with_sigsetjmp(savemask: c_int, closure_env_ptr: *mut c_void, closure_code: extern "C" fn(jbuf: *const SigJmpBufFields, env_ptr: *mut c_void) -> c_int) -> c_int;
+    fn call_closure_with_sigsetjmp(
+        savemask: c_int,
+        closure_env_ptr: *mut c_void,
+        closure_code: extern "C" fn(jbuf: *const SigJmpBufFields, env_ptr: *mut c_void) -> c_int,
+    ) -> c_int;
 }
 
 /// Covers the usual use case for setjmp: it invokes the callback, and the code
@@ -76,6 +83,10 @@ where
         // Therefore, we need to forget about our own ownership of the callback now.
         core::mem::forget(callback);
 
-        call_closure_with_sigsetjmp(savemask, closure_env_ptr as *mut c_void, call_from_c_to_rust::<F>)
+        call_closure_with_sigsetjmp(
+            savemask,
+            closure_env_ptr as *mut c_void,
+            call_from_c_to_rust::<F>,
+        )
     }
 }

--- a/src/glibc_compat.rs
+++ b/src/glibc_compat.rs
@@ -3,6 +3,9 @@ use core::marker::PhantomData;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 const JMP_BUF_SIZE: usize = 8;
 
+#[cfg(target_arch = "riscv64")]
+const JMP_BUF_SIZE: usize = 14 /* pc + regs + sp */ + crate::riscv64::floating_point_registers();
+
 /// `JmpBufFields` are the accessible fields when viewed via a JmpBuf pointer.
 /// But also: You shouldn't be poking at these!
 #[repr(C)]

--- a/src/glibc_compat.rs
+++ b/src/glibc_compat.rs
@@ -1,10 +1,13 @@
 use core::marker::PhantomData;
 
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+const JMP_BUF_SIZE: usize = 8;
+
 /// `JmpBufFields` are the accessible fields when viewed via a JmpBuf pointer.
 /// But also: You shouldn't be poking at these!
 #[repr(C)]
 pub struct JmpBufFields {
-    _buf: [u64; 8],
+    _buf: [u64; JMP_BUF_SIZE],
     _neither_send_nor_sync: PhantomData<*const u8>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,8 @@ use libc::c_int;
 mod glibc_compat;
 #[cfg(target_os = "macos")]
 mod macos_compat;
+#[cfg(target_arch = "riscv64")]
+mod riscv64;
 #[cfg(target_os = "linux")]
 use glibc_compat as struct_defs;
 #[cfg(target_os = "macos")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,9 +178,9 @@
 
 use libc::c_int;
 
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[cfg(target_os = "linux")]
 mod glibc_compat;
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+#[cfg(target_os = "macos")]
 mod macos_compat;
 #[cfg(target_os = "linux")]
 use glibc_compat as struct_defs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,8 +190,6 @@ use macos_compat as struct_defs;
 pub use crate::struct_defs::{JmpBufFields, JmpBufStruct};
 pub use crate::struct_defs::{SigJmpBufFields, SigJmpBufStruct};
 
-
-
 /// This is the type of the first argument that is fed to longjmp.
 pub type JmpBuf = *const JmpBufFields;
 
@@ -399,8 +397,8 @@ mod tests {
 
 #[cfg(test)]
 mod tests_of_drop_interaction {
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use super::{call_with_setjmp, call_with_sigsetjmp};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     struct IncrementOnDrop(&'static str, &'static AtomicUsize);
     impl IncrementOnDrop {
         fn new(name: &'static str, state: &'static AtomicUsize) -> Self {
@@ -424,7 +422,10 @@ mod tests_of_drop_interaction {
             let _own_it = iod;
             0
         });
-        println!("callback done, drop counter: {}", STATE.load(Ordering::Relaxed));
+        println!(
+            "callback done, drop counter: {}",
+            STATE.load(Ordering::Relaxed)
+        );
         assert_eq!(STATE.load(Ordering::Relaxed), 1);
         let iod = IncrementOnDrop::new("iod", &STATE);
         call_with_setjmp(move |_env| {
@@ -432,7 +433,10 @@ mod tests_of_drop_interaction {
             let _own_it = iod;
             0
         });
-        println!("callback done, drop counter: {}", STATE.load(Ordering::Relaxed));
+        println!(
+            "callback done, drop counter: {}",
+            STATE.load(Ordering::Relaxed)
+        );
         assert_eq!(STATE.load(Ordering::Relaxed), 2);
     }
 
@@ -445,7 +449,10 @@ mod tests_of_drop_interaction {
             let _own_it = iod;
             0
         });
-        println!("callback done, drop counter: {}", STATE.load(Ordering::Relaxed));
+        println!(
+            "callback done, drop counter: {}",
+            STATE.load(Ordering::Relaxed)
+        );
         assert_eq!(STATE.load(Ordering::Relaxed), 1);
         let iod = IncrementOnDrop::new("iod", &STATE);
         call_with_sigsetjmp(true, move |_env| {
@@ -453,7 +460,10 @@ mod tests_of_drop_interaction {
             let _own_it = iod;
             0
         });
-        println!("callback done, drop counter: {}", STATE.load(Ordering::Relaxed));
+        println!(
+            "callback done, drop counter: {}",
+            STATE.load(Ordering::Relaxed)
+        );
         assert_eq!(STATE.load(Ordering::Relaxed), 2);
     }
 
@@ -475,7 +485,10 @@ mod tests_of_drop_interaction {
             let _own_it = iod;
             unsafe { longjmp(env1, 4) }
         });
-        println!("callback done, drop counter: {}", STATE.load(Ordering::Relaxed));
+        println!(
+            "callback done, drop counter: {}",
+            STATE.load(Ordering::Relaxed)
+        );
         assert_eq!(STATE.load(Ordering::Relaxed), 0);
     }
 }

--- a/src/riscv64.rs
+++ b/src/riscv64.rs
@@ -1,0 +1,11 @@
+include!(concat!(env!("OUT_DIR"), "/riscv64_consts.rs"));
+
+pub const fn floating_point_registers() -> usize {
+    if FLOAT_ABI_DOUBLE {
+        12
+    } else if !FLOAT_ABI_SOFT {
+        panic!("unsupported number of floating point registers");
+    } else {
+        0
+    }
+}


### PR DESCRIPTION
I am adding support for RISC V architecture.

In order to do so, I also needed to disable `macos_compat` compilation for targets different than macos. This is because at the moment there is not support for RISC V for mac, and it is not possible for me to get the correct layout of `JmpBufFields` or `SigJmpBufFields`.

~~Unfortunately tests are failing on my `riscv64gc-unknown-linux` machine, therefore this is still in draft. I still have to dig deeper, but any help is more than welcome.~~

Things looks fine, but if you give a better look it is probably better.