### PR TITLE
Fix jmp_buf definition for aarch64

### DIFF
--- a/src/glibc_compat.rs
+++ b/src/glibc_compat.rs
@@ -2,9 +2,18 @@ use core::marker::PhantomData;
 
 /// `JmpBufFields` are the accessible fields when viewed via a JmpBuf pointer.
 /// But also: You shouldn't be poking at these!
+
+#[cfg(target_arch = "x86_64")]
 #[repr(C)]
 pub struct JmpBufFields {
     _buf: [u64; 8],
+    _neither_send_nor_sync: PhantomData<*const u8>,
+}
+
+#[cfg(target_arch = "aarch64")]
+#[repr(C)]
+pub struct JmpBufFields {
+    _buf: [u64; 22],
     _neither_send_nor_sync: PhantomData<*const u8>,
 }
 


### PR DESCRIPTION
Tests failed when compiled on `aarch64` architecture:
```
root@2f0db9d9773e:/opt# RUST_BACKTRACE=1 cargo test
   Compiling cee-scape v0.2.0 (/opt)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.48s
     Running unittests src/lib.rs (target/debug/deps/cee_scape-256b6a0f5e69ffce)

running 10 tests
test tests::c_integration ... ok
test tests::check_control_flow_details_1 ... ok
test tests::check_control_flow_details_3 ... ok
test tests::check_control_flow_details_2 ... ok
test tests::setjmp_basically_works ... ok
test tests::sigsetjmp_basically_works ... ok
test tests_of_drop_interaction::does_ptr_read_cause_a_double_drop_for_sigsetjmp ... ok
test tests_of_drop_interaction::does_ptr_read_cause_a_double_drop_for_setjmp ... ok
test tests_of_drop_interaction::mix_drop_with_longjmp ... ok
test tests::check_c_layout ... FAILED

failures:

---- tests::check_c_layout stdout ----
Note: C jmp_buf/sigjmp_buf layout info: LayoutOfJmpBufs { jb_size: 312, jb_align: 8, sigjb_size: 312, sigjb_align: 8 }

thread 'tests::check_c_layout' panicked at src/lib.rs:393:9:
assertion `left == right` failed
  left: 312
 right: 200
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/core/src/panicking.rs:75:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/core/src/panicking.rs:387:5
   4: cee_scape::tests::check_c_layout
             at ./src/lib.rs:393:9
   5: cee_scape::tests::check_c_layout::{{closure}}
             at ./src/lib.rs:373:24
   6: core::ops::function::FnOnce::call_once
             at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/core/src/ops/function.rs:250:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    tests::check_c_layout

test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s

error: test failed, to rerun pass `--lib`
```
This was tested using the `arm64v8/rust` container image from Docker.io.

Inspecting the cause I found that the C definitions of `jmp_buf` are different:
On `aarch64`: `__extension__ typedef unsigned long long __jmp_buf [22];`
On `x86_64`: `typedef long int __jmp_buf[8];`

You may want to add test coverage for this architecture.